### PR TITLE
Disable dll import/export for windows static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ test_big_endian(WORDS_BIGENDIAN)
 #/* 1234 = LIL_ENDIAN, 4321 = BIGENDIAN */
 
 if(WORDS_BIGENDIAN)
-    add_definitions("-DPLATFORM_BIGENDIAN")	
+    add_definitions("-DPLATFORM_BIGENDIAN")
 else(WORDS_BIGENDIAN)
     add_definitions("-DPLATFORM_LITTLEENDIAN")
 endif(WORDS_BIGENDIAN)
@@ -152,20 +152,23 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
 endif()
 
 
-# export all the symbols for ChemDraw on MSVC                                                 
-if((MSVC AND BUILD_SHARED_LIBS) OR ((NOT MSVC) AND WIN32))                                
-    set_target_properties(ChemDraw PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)                
-endif()                                                                                       
-                                                                                              
-if(MSVC)                                                                                      
-  ADD_DEFINITIONS("-DTARGET_API_LIB -D_WINDOWS -DTARGET_OS_WIN32 -DHAVE_EXPAT_CONFIG_H")      
-  # we don't really control chemdraw source code, so suppress warnings                        
-  target_compile_options(ChemDraw PRIVATE "/W0")                                              
-else()                                                                                        
-  ADD_DEFINITIONS("-DTARGET_API_LIB -D__linux -DHAVE_EXPAT_CONFIG_H")                         
-  # we don't really control chemdraw source code, so suppress warnings                        
-  target_compile_options(ChemDraw PRIVATE -w -Wno-unknown-pragmas -Wno-error)                 
-endif()                                                                                       
+# on windows, disable dll import/export macros for static builds.
+# for dynamic builds, export all the symbols for ChemDraw on MSVC
+if(WIN32 AND NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(ChemDraw PRIVATE CHEMDRAW_STATIC_LINK)
+elseif((MSVC AND BUILD_SHARED_LIBS) OR ((NOT MSVC) AND WIN32))
+    set_target_properties(ChemDraw PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+endif()
+
+if(MSVC)
+  ADD_DEFINITIONS("-DTARGET_API_LIB -D_WINDOWS -DTARGET_OS_WIN32 -DHAVE_EXPAT_CONFIG_H")
+  # we don't really control chemdraw source code, so suppress warnings
+  target_compile_options(ChemDraw PRIVATE "/W0")
+else()
+  ADD_DEFINITIONS("-DTARGET_API_LIB -D__linux -DHAVE_EXPAT_CONFIG_H")
+  # we don't really control chemdraw source code, so suppress warnings
+  target_compile_options(ChemDraw PRIVATE -w -Wno-unknown-pragmas -Wno-error)
+endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses -Wno-pointer-bool-conversion -Wno-unused-value -Wno-unsequenced -Wno-constant-logical-operand")

--- a/chemdraw/CoreChemistryAPI.h
+++ b/chemdraw/CoreChemistryAPI.h
@@ -14,7 +14,9 @@
 # endif
 #endif
 #if defined(_WIN32) || defined(__CYGWIN__)
-  #ifdef CHEMDRAW_BUILD
+  #if defined(CHEMDRAW_STATIC_LINK)
+    #define CORE_CHEMISTRY_API
+  #elif defined(CHEMDRAW_BUILD)
     // building the DLL
     #define CORE_CHEMISTRY_API __declspec(dllexport)
   #else


### PR DESCRIPTION
Any builds using windows static libraries will fail, because windows builds always include the dll import export macros. These macros will add prefixes to the imported symbol names that can't be satisfied by the generated static libraries, triggering build failures:
```
cmd.exe /C "cd . && C:\mingw64\bin\c++.exe -O3 -DNDEBUG -Wl,--gc-sections @CMakeFiles\sketcher_app.rsp -o sketcher_app.exe -Wl,--out-implib,libsketcher_app.dll.a -Wl,--major-image-version,0,--minor-image-version,0  && cd ."
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x3a0d): undefined reference to `__imp__ZNK9CDXObject16ContainedObjectsEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x569e): undefined reference to `__imp__ZTV10CDXistream'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x56cd): undefined reference to `__imp__Z21CDXReadDocFromStorageR13CDXDataSourceb'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x56ff): undefined reference to `__imp__ZN11CDXMLParserC1Ev'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x59bc): undefined reference to `__imp__ZN11CDXMLParser15ReleaseDocumentEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x59cd): undefined reference to `__imp__ZN11CDXMLParserD1Ev'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x5c42): undefined reference to `__imp__ZN11CDXMLParserD1Ev'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x689c): undefined reference to `__imp__ZNK9CDXObject16ContainedObjectsEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x98b6): undefined reference to `__imp__ZN11CDXMLParserC1Ev'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x9d6f): undefined reference to `__imp__ZN11CDXMLParserD1Ev'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(chemdraw.cpp.obj):chemdraw.cpp:(.text+0x9f01): undefined reference to `__imp__ZN11CDXMLParserD1Ev'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(fragment.cpp.obj):fragment.cpp:(.text+0x219f): undefined reference to `__imp__ZNK9CDXObject16ContainedObjectsEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(node.cpp.obj):node.cpp:(.text+0x26e5): undefined reference to `__imp__ZNK9CDXObject16ContainedObjectsEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(node.cpp.obj):node.cpp:(.text+0x274a): undefined reference to `__imp__ZNK7CDXText7GetTextEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(node.cpp.obj):node.cpp:(.text+0x2786): undefined reference to `__imp__ZNK7CDXText7GetTextEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(reaction.cpp.obj):reaction.cpp:(.text+0x4ed9): undefined reference to `__imp__ZNK9CDXObject16ContainedObjectsEv'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: external/rdkit-2025.03.6/lib/libRDKitRDChemDrawLib.a(bracket.cpp.obj):bracket.cpp:(.text+0x1cff): undefined reference to `__imp__ZNK9CDXObject16ContainedObjectsEv'
```

This patch adds a macro that allows disabling the dll imports/exports on Windows.